### PR TITLE
toTex function

### DIFF
--- a/lib/toTex.js
+++ b/lib/toTex.js
@@ -1,6 +1,6 @@
 /**
-   * toTex - return a string representation of the nodes in LaTeX
-   */
+  * toTex - return a string representation of the nodes in LaTeX
+  */
 
 const isNeg = (node) => {
     return node.type === 'Operation' && node.op === 'neg';
@@ -8,10 +8,6 @@ const isNeg = (node) => {
 
 const isAdd = (node) => {
     return node.type === 'Operation' && node.op === 'add';
-};
-
-const isMul = (node) => {
-    return node.type === 'Operation' && node.op === '*' && node.args.length > 1;
 };
 
 function toTexOperation(node, parent){
@@ -44,7 +40,7 @@ function toTexOperation(node, parent){
             return node.args.map(arg => toTex(arg, node)).join(` `);
         } else {
             //e.g 2 * x
-            return node.args.map(arg => toTex(arg, node)).join(` \ast `); // ast for asterisk and \time for x
+            return node.args.map(arg => toTex(arg, node)).join(` \times `);
         }
     case 'div':
         result = '';

--- a/lib/toTex.js
+++ b/lib/toTex.js
@@ -1,0 +1,93 @@
+/**
+   * toTex - return a string representation of the nodes in LaTeX
+   */
+
+const isNeg = (node) => {
+    return node.type === 'Operation' && node.op === 'neg';
+};
+
+const isAdd = (node) => {
+    return node.type === 'Operation' && node.op === 'add';
+};
+
+const isMul = (node) => {
+    return node.type === 'Operation' && node.op === '*' && node.args.length > 1;
+};
+
+function toTexOperation(node, parent){
+    let result;
+
+    switch(node.op){
+    case 'add':
+        //e.g a + (-a) => a - a       
+        result = toTex(node.args[0], node);
+        for (let i = 1; i < node.args.length; i++){
+            const arg = node.args[i];
+            if (isNeg(arg) && arg.wasMinus){
+                result += ` - ${toTex(arg.args[0], node)}`; 
+            } else {
+                result += ` + ${toTex(arg, node)}`;
+            }
+        }
+        return parent ? `\left(${result}\right)` : result;
+    case 'neg':
+        return `-${toTex(node.args[0], node)}`;
+    case 'pos':
+        return `+${toTex(node.args[0], node)}`;
+    case 'pn':
+        throw new Error(`we don't handle 'pn' operations yet`);
+    case 'np':
+        throw new Error(`we don't handle 'np' operations yet`);
+    case 'mul':
+        if (node.implicit) {
+            //e.g 2 x 
+            return node.args.map(arg => toTex(arg, node)).join(` `);
+        } else {
+            //e.g 2 * x
+            return node.args.map(arg => toTex(arg, node)).join(` \ast `); // ast for asterisk and \time for x
+        }
+    case 'div':
+        result = '';
+        result += '\frac';
+        //add parentheses when numerator or denominator has multiple terms
+        //e.g latex fractions: \frac{a}{b} => a/b
+        result += `{${toTex(node.args[1], node)}}`;
+        return result;
+    case 'pow':
+        //
+        return `${toTex(node.args[0], node)}^{${toTex(node.args[1], node)}}`;
+    case 'fact':
+        throw new Error(`we don't handle 'fact' operations yet`);
+    default:
+        throw new Error('unrecognized operation');
+    }
+}
+
+export default function toTex(node, parent = null){
+    switch(node.type){
+        // regular non-leaf nodes
+    case 'Relation':
+        // e.g a = b or ax^3 + bx^2 + cx + d = 0
+        return node.args.map(arg => toTex(arg, node)).join(` ${node.rel} `);
+    case 'Operation':
+        return toTexOperation(node, parent);
+    case 'Function':
+        // e.g f(x, y, z)
+        return `${node.fn}(${node.args.map(arg => toTex(arg, node)).join(', ')})`;
+
+        //leaf nodes
+    case 'Identifier':
+        return node.name;
+    case 'Number':
+        return node.value;
+
+        //irregular node-leaf nodes
+    case 'Brackets':
+        //e.g [[2,3], [3,4]]
+        return `\lbrack${toTex(node.content, node)}\rbrack`;
+
+    default:
+        console.log(node); // eslint-disable-line no-console
+        throw new Error('unrecognized node');
+    }
+}

--- a/lib/toTex.js
+++ b/lib/toTex.js
@@ -40,7 +40,7 @@ function toTexOperation(node, parent){
             return node.args.map(arg => toTex(arg, node)).join(` `);
         } else {
             //e.g 2 * x
-            return node.args.map(arg => toTex(arg, node)).join(` \times `);
+            return node.args.map(arg => toTex(arg, node)).join(` \\times `);
         }
     case 'div':
         result = '';

--- a/lib/toTex.js
+++ b/lib/toTex.js
@@ -29,7 +29,7 @@ function toTexOperation(node, parent){
                 result += ` + ${toTex(arg, node)}`;
             }
         }
-        return parent ? `\left(${result}\right)` : result;
+        return parent ? `\\left(${result}\\right)` : result;
     case 'neg':
         return `-${toTex(node.args[0], node)}`;
     case 'pos':
@@ -48,10 +48,11 @@ function toTexOperation(node, parent){
         }
     case 'div':
         result = '';
-        result += '\frac';
+        result += '\\frac';
         //add parentheses when numerator or denominator has multiple terms
         //e.g latex fractions: \frac{a}{b} => a/b
-        result += `{${toTex(node.args[1], node)}}`;
+        result += `{${toTex(node.args[0], node)}}`; 
+        result += `{${toTex(node.args[1], node)}}`; 
         return result;
     case 'pow':
         //

--- a/test/toTex_test.js
+++ b/test/toTex_test.js
@@ -24,4 +24,10 @@ describe("toTex", () => {
         assert.equal(toTex(parse('x/2')), '\\frac{x}{2}');
         assert.equal(toTex(parse('(x+2)/(x+3)')), '\\frac{\\left(x + 2\\right)}{\\left(x + 3\\right)}');
     });
+
+    it("handles equations correctly", () => {
+        assert.equal(toTex(parse('x = 5/2')), 'x = \\frac{5}{2}');
+        assert.equal(toTex(parse('x = 3 * (2/x)')), 'x = 3 \\times \\frac{2}{x}'); 
+        assert.equal(toTex(parse('3 + x = 3/x')), '\\left(3 + x\\right) = \\frac{3}{x}'); 
+    });
 });

--- a/test/toTex_test.js
+++ b/test/toTex_test.js
@@ -5,16 +5,23 @@ import toTex from '../lib/toTex.js'
 
 describe("toTex", () => {
   it("handles wasMinus correctly", () => {
-    assert.equal(toTex(parse('1 - 2')), '1 - 2');
+    // arithmetic
+    assert.equal(toTex(parse('1 + -2')), '1 + -2');
     assert.equal(toTex(parse('1 - -2')), '1 - -2');
     assert.equal(toTex(parse('a - b')), 'a - b');
     assert.equal(toTex(parse('a + -b')), 'a + -b');
+    assert.equal(toTex(parse('1 * 2')), '1 ast 2');
+    // implicit multiplication
+    assert.equal(toTex(parse('x * 2x')), 'x ast 2 x'); 
+    assert.equal(toTex(parse('-3')), '-3');
+    // brackets
+    //assert.equal(toTex(parse('[2 , 3]')), '');
   });
 
-  // TODO(kevinb) enable these tests after updating division parsing behavior
-  it.skip("handles fractions correctly", () => {
-    assert.equal(toTex(parse('1/2/3')), '1 / 2 / 3');
-    assert.equal(parse('1*2/3'), '1 * (2 / 3)');
-    // assert.equal(toTex(parser.parse('(1*2)/3')), '(1 * 2) / 3');
+  it("handles fractions correctly", () => {
+    assert.equal(toTex(parse('1/2')), '\\frac{1}{2}');
+    assert.equal(toTex(parse('1/2/3')), '\\frac{\\frac{1}{2}}{3}');
+    assert.equal(toTex(parse('x/2')), '\\frac{x}{2}');
+    assert.equal(toTex(parse('(x+2)/(x+3)')), '\\frac{\\left(x + 2\\right)}{\\left(x + 3\\right)}');
   });
 });

--- a/test/toTex_test.js
+++ b/test/toTex_test.js
@@ -4,24 +4,24 @@ import parse from '../lib/parse'
 import toTex from '../lib/toTex.js'
 
 describe("toTex", () => {
-  it("handles wasMinus correctly", () => {
-    // arithmetic
-    assert.equal(toTex(parse('1 + -2')), '1 + -2');
-    assert.equal(toTex(parse('1 - -2')), '1 - -2');
-    assert.equal(toTex(parse('a - b')), 'a - b');
-    assert.equal(toTex(parse('a + -b')), 'a + -b');
-    assert.equal(toTex(parse('1 * 2')), '1 ast 2');
-    // implicit multiplication
-    assert.equal(toTex(parse('x * 2x')), 'x ast 2 x'); 
-    assert.equal(toTex(parse('-3')), '-3');
-    // brackets
-    //assert.equal(toTex(parse('[2 , 3]')), '');
-  });
+    it("handles wasMinus correctly", () => {
+        // arithmetic
+        assert.equal(toTex(parse('1 + -2')), '1 + -2');
+        assert.equal(toTex(parse('1 - -2')), '1 - -2');
+        assert.equal(toTex(parse('a - b')), 'a - b');
+        assert.equal(toTex(parse('a + -b')), 'a + -b');
+        assert.equal(toTex(parse('1 * 2')), '1 ast 2');
+        // implicit multiplication
+        assert.equal(toTex(parse('x * 2x')), 'x ast 2 x');
+        assert.equal(toTex(parse('-3')), '-3');
+        // brackets
+        //assert.equal(toTex(parse('[2 , 3]')), '');
+    });
 
-  it("handles fractions correctly", () => {
-    assert.equal(toTex(parse('1/2')), '\\frac{1}{2}');
-    assert.equal(toTex(parse('1/2/3')), '\\frac{\\frac{1}{2}}{3}');
-    assert.equal(toTex(parse('x/2')), '\\frac{x}{2}');
-    assert.equal(toTex(parse('(x+2)/(x+3)')), '\\frac{\\left(x + 2\\right)}{\\left(x + 3\\right)}');
-  });
+    it("handles fractions correctly", () => {
+        assert.equal(toTex(parse('1/2')), '\\frac{1}{2}');
+        assert.equal(toTex(parse('1/2/3')), '\\frac{\\frac{1}{2}}{3}');
+        assert.equal(toTex(parse('x/2')), '\\frac{x}{2}');
+        assert.equal(toTex(parse('(x+2)/(x+3)')), '\\frac{\\left(x + 2\\right)}{\\left(x + 3\\right)}');
+    });
 });

--- a/test/toTex_test.js
+++ b/test/toTex_test.js
@@ -1,0 +1,20 @@
+import assert from 'assert'
+
+import parse from '../lib/parse'
+import toTex from '../lib/toTex.js'
+
+describe("toTex", () => {
+  it("handles wasMinus correctly", () => {
+    assert.equal(toTex(parse('1 - 2')), '1 - 2');
+    assert.equal(toTex(parse('1 - -2')), '1 - -2');
+    assert.equal(toTex(parse('a - b')), 'a - b');
+    assert.equal(toTex(parse('a + -b')), 'a + -b');
+  });
+
+  // TODO(kevinb) enable these tests after updating division parsing behavior
+  it.skip("handles fractions correctly", () => {
+    assert.equal(toTex(parse('1/2/3')), '1 / 2 / 3');
+    assert.equal(parse('1*2/3'), '1 * (2 / 3)');
+    // assert.equal(toTex(parser.parse('(1*2)/3')), '(1 * 2) / 3');
+  });
+});

--- a/test/toTex_test.js
+++ b/test/toTex_test.js
@@ -10,9 +10,9 @@ describe("toTex", () => {
         assert.equal(toTex(parse('1 - -2')), '1 - -2');
         assert.equal(toTex(parse('a - b')), 'a - b');
         assert.equal(toTex(parse('a + -b')), 'a + -b');
-        assert.equal(toTex(parse('1 * 2')), '1 ast 2');
+        assert.equal(toTex(parse('1 * 2')), '1 \\times 2');
         // implicit multiplication
-        assert.equal(toTex(parse('x * 2x')), 'x ast 2 x');
+        assert.equal(toTex(parse('x * 2x')), 'x \\times 2 x');
         assert.equal(toTex(parse('-3')), '-3');
         // brackets
         //assert.equal(toTex(parse('[2 , 3]')), '');


### PR DESCRIPTION
fixed and added test cases for toTex (fractions included)

needed the "\\" because single slash was escape sequence. 