### PR TITLE
Subscript fix

### DIFF
--- a/docs/math-parser.js
+++ b/docs/math-parser.js
@@ -450,11 +450,11 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function isIdentifierToken(token) {
-    return token && /[a-zA-Z][a-zA-Z0-9]*/.test(token.value);
+    return token && /^[a-zA-Z][a-zA-Z0-9]*$/.test(token.value);
 }
 
 function isNumberToken(token) {
-    return token && /\d*\.\d+|\d+\.\d*|\d+/.test(token.value);
+    return token && /^(\d*\.\d+|\d+\.\d*|\d+)$/.test(token.value);
 }
 
 var tokenPattern = /\.\.\.|[a-zA-Z][a-zA-Z0-9]*|<=|>=|!=|[\<\>\!\=\(\)\+\-\/\*\^\<\>|\,\#\_]|\d*\.\d+|\d+\.\d*|\d+/;

--- a/lib/__test__/__snapshots__/parser.test.js.snap
+++ b/lib/__test__/__snapshots__/parser.test.js.snap
@@ -2337,6 +2337,17 @@ exports[`Parser.parse subscripts #a_0 1`] = `
 }
 `;
 
+exports[`Parser.parse subscripts #a_a3 1`] = `
+{
+    "type": "Placeholder",
+    "subscript": {
+        "type": "Identifier",
+        "name": "a3"
+    },
+    "name": "a"
+}
+`;
+
 exports[`Parser.parse subscripts a_0 1`] = `
 {
     "type": "Identifier",

--- a/lib/__test__/parser.test.js
+++ b/lib/__test__/parser.test.js
@@ -171,6 +171,7 @@ describe('Parser.parse', () => {
         'a_xyz',
         'a_0^2',
         '#a_0',
+        '#a_a3',
         // 'a_-1',
         // 'a_(m+n),
         // 'a_b_c',

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -16,11 +16,11 @@ import {build, query} from 'math-nodes'
 import {traverse} from 'math-traverse'
 
 function isIdentifierToken(token) {
-    return token && /^[a-zA-Z][a-zA-Z0-9]*$/.test(token.value);
+    return token && /^[a-zA-Z][a-zA-Z0-9]*$/.test(token.value)
 }
 
 function isNumberToken(token) {
-    return token && /^(\d*\.\d+|\d+\.\d*|\d+)$/.test(token.value);
+    return token && /^(\d*\.\d+|\d+\.\d*|\d+)$/.test(token.value)
 }
 
 const tokenPattern =

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -16,11 +16,11 @@ import {build, query} from 'math-nodes'
 import {traverse} from 'math-traverse'
 
 function isIdentifierToken(token) {
-    return token && /[a-zA-Z][a-zA-Z0-9]*/.test(token.value)
+    return token && /^[a-zA-Z][a-zA-Z0-9]*$/.test(token.value);
 }
 
 function isNumberToken(token) {
-    return token && /\d*\.\d+|\d+\.\d*|\d+/.test(token.value)
+    return token && /^(\d*\.\d+|\d+\.\d*|\d+)$/.test(token.value);
 }
 
 const tokenPattern =


### PR DESCRIPTION
Makes sure that subscripts are identified correctly as numbers or identifiers. Before isIdentifierToken and isNumberToken were just checking if they were contained anywhere in the string, but now they make sure they match with the whole string. This stops isNumberToken from classifying something as a number just because it contains a number. Resolves #59.