### PR TITLE
Relation fix

### DIFF
--- a/docs/math-parser.js
+++ b/docs/math-parser.js
@@ -628,7 +628,7 @@ var Parser = function () {
                     args: []
                 };
 
-                relations.forEach(function (item, index) {
+                relations.forEach(function (item) {
                     if (item.op !== output.op) {
                         output.args.unshift(item.args[1]);
 

--- a/docs/math-parser.js
+++ b/docs/math-parser.js
@@ -620,11 +620,32 @@ var Parser = function () {
             args.push(right);
 
             if (relations.length > 1) {
-                return {
+                relations.reverse();
+
+                let output = {
                     type: 'Apply',
                     op: relations[0].op,
-                    args: args
+                    args: []
                 };
+
+                relations.forEach(function (item, index) {
+                    if (item.op !== output.op) {
+                        output.args.unshift(relations[index - 1].args[0]);
+
+                        output = {
+                            type: 'Apply',
+                            op: item.op,
+                            args: [output]
+                        };
+                    }
+                    else {
+                      output.args.unshift(item.args[1]);
+                    }
+                });
+
+                output.args.unshift(relations[relations.length - 1].args[0]);
+
+                return output;
             } else if (relations.length > 0) {
                 return relations[0];
             } else {

--- a/docs/math-parser.js
+++ b/docs/math-parser.js
@@ -630,7 +630,7 @@ var Parser = function () {
 
                 relations.forEach(function (item, index) {
                     if (item.op !== output.op) {
-                        output.args.unshift(relations[index - 1].args[0]);
+                        output.args.unshift(item.args[1]);
 
                         output = {
                             type: 'Apply',

--- a/docs/math-parser.js
+++ b/docs/math-parser.js
@@ -1,70 +1,70 @@
 module.exports =
 /******/ (function(modules) { // webpackBootstrap
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
+/******/        // The module cache
+/******/        var installedModules = {};
 
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/        // The require function
+/******/        function __webpack_require__(moduleId) {
 
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
-/******/ 			return installedModules[moduleId].exports;
+/******/                // Check if module is in cache
+/******/                if(installedModules[moduleId])
+/******/                        return installedModules[moduleId].exports;
 
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
+/******/                // Create a new module (and put it into the cache)
+/******/                var module = installedModules[moduleId] = {
+/******/                        i: moduleId,
+/******/                        l: false,
+/******/                        exports: {}
+/******/                };
 
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/                // Execute the module function
+/******/                modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
 
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
+/******/                // Flag the module as loaded
+/******/                module.l = true;
 
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
+/******/                // Return the exports of the module
+/******/                return module.exports;
+/******/        }
 
 
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
+/******/        // expose the modules object (__webpack_modules__)
+/******/        __webpack_require__.m = modules;
 
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
+/******/        // expose the module cache
+/******/        __webpack_require__.c = installedModules;
 
-/******/ 	// identity function for calling harmony imports with the correct context
-/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/        // identity function for calling harmony imports with the correct context
+/******/        __webpack_require__.i = function(value) { return value; };
 
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
+/******/        // define getter function for harmony exports
+/******/        __webpack_require__.d = function(exports, name, getter) {
+/******/                if(!__webpack_require__.o(exports, name)) {
+/******/                        Object.defineProperty(exports, name, {
+/******/                                configurable: false,
+/******/                                enumerable: true,
+/******/                                get: getter
+/******/                        });
+/******/                }
+/******/        };
 
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
+/******/        // getDefaultExport function for compatibility with non-harmony modules
+/******/        __webpack_require__.n = function(module) {
+/******/                var getter = module && module.__esModule ?
+/******/                        function getDefault() { return module['default']; } :
+/******/                        function getModuleExports() { return module; };
+/******/                __webpack_require__.d(getter, 'a', getter);
+/******/                return getter;
+/******/        };
 
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/        // Object.prototype.hasOwnProperty.call
+/******/        __webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
 
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "";
+/******/        // __webpack_public_path__
+/******/        __webpack_require__.p = "";
 
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 4);
+/******/        // Load entry module and return exports
+/******/        return __webpack_require__(__webpack_require__.s = 4);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -73,71 +73,71 @@ module.exports =
 
 module.exports =
 /******/ (function(modules) { // webpackBootstrap
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
+/******/        // The module cache
+/******/        var installedModules = {};
 /******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/        // The require function
+/******/        function __webpack_require__(moduleId) {
 /******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
+/******/                // Check if module is in cache
+/******/                if(installedModules[moduleId]) {
+/******/                        return installedModules[moduleId].exports;
+/******/                }
+/******/                // Create a new module (and put it into the cache)
+/******/                var module = installedModules[moduleId] = {
+/******/                        i: moduleId,
+/******/                        l: false,
+/******/                        exports: {}
+/******/                };
 /******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/                // Execute the module function
+/******/                modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
 /******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
+/******/                // Flag the module as loaded
+/******/                module.l = true;
 /******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
+/******/                // Return the exports of the module
+/******/                return module.exports;
+/******/        }
 /******/
 /******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
+/******/        // expose the modules object (__webpack_modules__)
+/******/        __webpack_require__.m = modules;
 /******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
+/******/        // expose the module cache
+/******/        __webpack_require__.c = installedModules;
 /******/
-/******/ 	// identity function for calling harmony imports with the correct context
-/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/        // identity function for calling harmony imports with the correct context
+/******/        __webpack_require__.i = function(value) { return value; };
 /******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
+/******/        // define getter function for harmony exports
+/******/        __webpack_require__.d = function(exports, name, getter) {
+/******/                if(!__webpack_require__.o(exports, name)) {
+/******/                        Object.defineProperty(exports, name, {
+/******/                                configurable: false,
+/******/                                enumerable: true,
+/******/                                get: getter
+/******/                        });
+/******/                }
+/******/        };
 /******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
+/******/        // getDefaultExport function for compatibility with non-harmony modules
+/******/        __webpack_require__.n = function(module) {
+/******/                var getter = module && module.__esModule ?
+/******/                        function getDefault() { return module['default']; } :
+/******/                        function getModuleExports() { return module; };
+/******/                __webpack_require__.d(getter, 'a', getter);
+/******/                return getter;
+/******/        };
 /******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/        // Object.prototype.hasOwnProperty.call
+/******/        __webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
 /******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "";
+/******/        // __webpack_public_path__
+/******/        __webpack_require__.p = "";
 /******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/        // Load entry module and return exports
+/******/        return __webpack_require__(__webpack_require__.s = 2);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -620,32 +620,45 @@ var Parser = function () {
             args.push(right);
 
             if (relations.length > 1) {
-                relations.reverse();
+                relations.reverse()
 
                 let output = {
                     type: 'Apply',
+                    op: 'and',
+                    args: []
+                }
+
+                let current = {
+                    type: 'Apply',
                     op: relations[0].op,
                     args: []
-                };
+                }
 
                 relations.forEach(function (item) {
-                    if (item.op !== output.op) {
-                        output.args.unshift(item.args[1]);
+                    if (item.op !== current.op) {
+                        current.args.unshift(item.args[1])
 
-                        output = {
+                        output.args.unshift(current)
+
+                        current = {
                             type: 'Apply',
                             op: item.op,
-                            args: [output]
-                        };
+                            args: [item.args[1]]
+                        }
                     }
                     else {
-                      output.args.unshift(item.args[1]);
+                        current.args.unshift(item.args[1])
                     }
-                });
+                })
 
-                output.args.unshift(relations[relations.length - 1].args[0]);
+                current.args.unshift(relations[relations.length - 1].args[0])
+                output.args.unshift(current)
 
-                return output;
+                if (output.args.length === 1) {
+                    return output.args[0]
+                }
+
+                return output
             } else if (relations.length > 0) {
                 return relations[0];
             } else {
@@ -1187,71 +1200,71 @@ function print(node) {
 
 module.exports =
 /******/ (function(modules) { // webpackBootstrap
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
+/******/        // The module cache
+/******/        var installedModules = {};
 /******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/        // The require function
+/******/        function __webpack_require__(moduleId) {
 /******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
+/******/                // Check if module is in cache
+/******/                if(installedModules[moduleId]) {
+/******/                        return installedModules[moduleId].exports;
+/******/                }
+/******/                // Create a new module (and put it into the cache)
+/******/                var module = installedModules[moduleId] = {
+/******/                        i: moduleId,
+/******/                        l: false,
+/******/                        exports: {}
+/******/                };
 /******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/                // Execute the module function
+/******/                modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
 /******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
+/******/                // Flag the module as loaded
+/******/                module.l = true;
 /******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
+/******/                // Return the exports of the module
+/******/                return module.exports;
+/******/        }
 /******/
 /******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
+/******/        // expose the modules object (__webpack_modules__)
+/******/        __webpack_require__.m = modules;
 /******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
+/******/        // expose the module cache
+/******/        __webpack_require__.c = installedModules;
 /******/
-/******/ 	// identity function for calling harmony imports with the correct context
-/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/        // identity function for calling harmony imports with the correct context
+/******/        __webpack_require__.i = function(value) { return value; };
 /******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
+/******/        // define getter function for harmony exports
+/******/        __webpack_require__.d = function(exports, name, getter) {
+/******/                if(!__webpack_require__.o(exports, name)) {
+/******/                        Object.defineProperty(exports, name, {
+/******/                                configurable: false,
+/******/                                enumerable: true,
+/******/                                get: getter
+/******/                        });
+/******/                }
+/******/        };
 /******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
+/******/        // getDefaultExport function for compatibility with non-harmony modules
+/******/        __webpack_require__.n = function(module) {
+/******/                var getter = module && module.__esModule ?
+/******/                        function getDefault() { return module['default']; } :
+/******/                        function getModuleExports() { return module; };
+/******/                __webpack_require__.d(getter, 'a', getter);
+/******/                return getter;
+/******/        };
 /******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/        // Object.prototype.hasOwnProperty.call
+/******/        __webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
 /******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "";
+/******/        // __webpack_public_path__
+/******/        __webpack_require__.p = "";
 /******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/        // Load entry module and return exports
+/******/        return __webpack_require__(__webpack_require__.s = 2);
 /******/ })
 /************************************************************************/
 /******/ ([

--- a/lib/__test__/__snapshots__/parser.test.js.snap
+++ b/lib/__test__/__snapshots__/parser.test.js.snap
@@ -2165,6 +2165,70 @@ exports[`Parser.parse relations (n-ary) a = b = c 1`] = `
 }
 `;
 
+exports[`Parser.parse relations (n-ary) a = b >= c != d < e - f 1`] = `
+{
+    "type": "Apply",
+    "op": "eq",
+    "args": [
+        {
+            "type": "Identifier",
+            "name": "a"
+        },
+        {
+            "type": "Apply",
+            "op": "ge",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "b"
+                },
+                {
+                    "type": "Apply",
+                    "op": "ne",
+                    "args": [
+                        {
+                            "type": "Identifier",
+                            "name": "c"
+                        },
+                        {
+                            "type": "Apply",
+                            "op": "lt",
+                            "args": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "d"
+                                },
+                                {
+                                    "type": "Apply",
+                                    "op": "add",
+                                    "args": [
+                                        {
+                                            "type": "Identifier",
+                                            "name": "e"
+                                        },
+                                        {
+                                            "wasMinus": true,
+                                            "type": "Apply",
+                                            "op": "neg",
+                                            "args": [
+                                                {
+                                                    "type": "Identifier",
+                                                    "name": "f"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+`;
+
 exports[`Parser.parse relations (n-ary) a > b > c 1`] = `
 {
     "type": "Apply",

--- a/lib/__test__/__snapshots__/parser.test.js.snap
+++ b/lib/__test__/__snapshots__/parser.test.js.snap
@@ -2144,6 +2144,65 @@ exports[`Parser.parse relations (n-ary) a + b > c + d > e + f 1`] = `
 }
 `;
 
+exports[`Parser.parse relations (n-ary) a = b = c >= d <= e <= f 1`] = `
+{
+    "type": "Apply",
+    "op": "and",
+    "args": [
+        {
+            "type": "Apply",
+            "op": "eq",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "a"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "b"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "c"
+                }
+            ]
+        },
+        {
+            "type": "Apply",
+            "op": "ge",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "c"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "d"
+                }
+            ]
+        },
+        {
+            "type": "Apply",
+            "op": "le",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "d"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "e"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "f"
+                }
+            ]
+        }
+    ]
+}
+`;
+
 exports[`Parser.parse relations (n-ary) a = b = c 1`] = `
 {
     "type": "Apply",
@@ -2168,11 +2227,21 @@ exports[`Parser.parse relations (n-ary) a = b = c 1`] = `
 exports[`Parser.parse relations (n-ary) a = b >= c != d < e - f 1`] = `
 {
     "type": "Apply",
-    "op": "eq",
+    "op": "and",
     "args": [
         {
-            "type": "Identifier",
-            "name": "a"
+            "type": "Apply",
+            "op": "eq",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "a"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "b"
+                }
+            ]
         },
         {
             "type": "Apply",
@@ -2183,41 +2252,49 @@ exports[`Parser.parse relations (n-ary) a = b >= c != d < e - f 1`] = `
                     "name": "b"
                 },
                 {
+                    "type": "Identifier",
+                    "name": "c"
+                }
+            ]
+        },
+        {
+            "type": "Apply",
+            "op": "ne",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "c"
+                },
+                {
+                    "type": "Identifier",
+                    "name": "d"
+                }
+            ]
+        },
+        {
+            "type": "Apply",
+            "op": "lt",
+            "args": [
+                {
+                    "type": "Identifier",
+                    "name": "d"
+                },
+                {
                     "type": "Apply",
-                    "op": "ne",
+                    "op": "add",
                     "args": [
                         {
                             "type": "Identifier",
-                            "name": "c"
+                            "name": "e"
                         },
                         {
+                            "wasMinus": true,
                             "type": "Apply",
-                            "op": "lt",
+                            "op": "neg",
                             "args": [
                                 {
                                     "type": "Identifier",
-                                    "name": "d"
-                                },
-                                {
-                                    "type": "Apply",
-                                    "op": "add",
-                                    "args": [
-                                        {
-                                            "type": "Identifier",
-                                            "name": "e"
-                                        },
-                                        {
-                                            "wasMinus": true,
-                                            "type": "Apply",
-                                            "op": "neg",
-                                            "args": [
-                                                {
-                                                    "type": "Identifier",
-                                                    "name": "f"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                                    "name": "f"
                                 }
                             ]
                         }

--- a/lib/__test__/parser.test.js
+++ b/lib/__test__/parser.test.js
@@ -141,6 +141,7 @@ describe('Parser.parse', () => {
         'a + b > c + d > e + f',
         'a != b != c',
         'a + b != c + d != e + f',
+        'a = b >= c != d < e - f'
     ])
 
     suite('systems of equations', [

--- a/lib/__test__/parser.test.js
+++ b/lib/__test__/parser.test.js
@@ -141,7 +141,8 @@ describe('Parser.parse', () => {
         'a + b > c + d > e + f',
         'a != b != c',
         'a + b != c + d != e + f',
-        'a = b >= c != d < e - f'
+        'a = b >= c != d < e - f',
+        'a = b = c >= d <= e <= f',
     ])
 
     suite('systems of equations', [

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -187,7 +187,7 @@ class Parser {
 
             relations.forEach(function (item, index) {
                 if (item.op !== output.op) {
-                    output.args.unshift(relations[index - 1].args[0])
+                    output.args.unshift(item.args[1])
 
                     output = {
                         type: 'Apply',

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -181,26 +181,39 @@ class Parser {
 
             let output = {
                 type: 'Apply',
+                op: 'and',
+                args: []
+            }
+
+            let current = {
+                type: 'Apply',
                 op: relations[0].op,
                 args: []
             }
 
             relations.forEach(function (item) {
-                if (item.op !== output.op) {
-                    output.args.unshift(item.args[1])
+                if (item.op !== current.op) {
+                    current.args.unshift(item.args[1])
 
-                    output = {
+                    output.args.unshift(current)
+
+                    current = {
                         type: 'Apply',
                         op: item.op,
-                        args: [output]
+                        args: [item.args[1]]
                     }
                 }
                 else {
-                    output.args.unshift(item.args[1])
+                    current.args.unshift(item.args[1])
                 }
             })
 
-            output.args.unshift(relations[relations.length - 1].args[0])
+            current.args.unshift(relations[relations.length - 1].args[0])
+            output.args.unshift(current)
+
+            if (output.args.length === 1) {
+                return output.args[0]
+            }
 
             return output
         } else if (relations.length > 0) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -177,11 +177,32 @@ class Parser {
         args.push(right)
 
         if (relations.length > 1) {
-            return {
+            relations.reverse()
+
+            let output = {
                 type: 'Apply',
                 op: relations[0].op,
-                args: args
+                args: []
             }
+
+            relations.forEach(function (item, index) {
+                if (item.op !== output.op) {
+                    output.args.unshift(relations[index - 1].args[0])
+
+                    output = {
+                        type: 'Apply',
+                        op: item.op,
+                        args: [output]
+                    }
+                }
+                else {
+                    output.args.unshift(item.args[1])
+                }
+            })
+
+            output.args.unshift(relations[relations.length - 1].args[0])
+
+            return output
         } else if (relations.length > 0) {
             return relations[0]
         } else {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -185,7 +185,7 @@ class Parser {
                 args: []
             }
 
-            relations.forEach(function (item, index) {
+            relations.forEach(function (item) {
                 if (item.op !== output.op) {
                     output.args.unshift(item.args[1])
 


### PR DESCRIPTION
Allows for multiple relations that are different ('a=b>=c'). It starts with the last relation and adds the RHS of it to the apply node. Once a different relation is reached, a new apply node is made with the old one as the child. Finally, the LHS of the very first relation is added. Resolves #60 